### PR TITLE
Stop ignoring .obj files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ artifacts/
 *_i.h
 *.ilk
 *.meta
-*.obj
 *.pch
 *.pdb
 *.pgc


### PR DESCRIPTION
I searched .obj files and found nones in my dev folder.  
.obj files [are 3D models files](https://en.wikipedia.org/wiki/Wavefront_.obj_file). Ignoring them causes... headaches.
