### PR TITLE
Linux Compatibility Fixes (part 1)

### DIFF
--- a/CKli.Core/CKliRootEnv.cs
+++ b/CKli.Core/CKliRootEnv.cs
@@ -330,7 +330,12 @@ public static partial class CKliRootEnv
     public static Mutex AcquireAppMutex( IActivityMonitor? monitor )
     {
         CheckInitialized();
-        var mutex = new Mutex( true, _appLocalDataPath, out var acquired );
+        // On Linux, named mutexes are implemented using named semaphores.
+        // Their names cannot contain slashes and must start with a leading slash (or it is implementation-defined).
+        // .NET handles the leading slash if it's missing, but it doesn't handle internal slashes.
+        // See: https://man7.org/linux/man-pages/man7/sem_overview.7.html
+        var mutexName = "Global\\" + _appLocalDataPath.ToString().Replace( Path.DirectorySeparatorChar, '_' ).Replace( ':', '_' );
+        var mutex = new Mutex( true, mutexName, out var acquired );
         if( !acquired )
         {
             var msg = $"Waiting for the '{_appLocalDataPath}' mutex to be released.";

--- a/CKli.Core/WorldDefinitionFile.cs
+++ b/CKli.Core/WorldDefinitionFile.cs
@@ -558,7 +558,7 @@ public sealed class WorldDefinitionFile
                                     var candidate = world.Stack.LocalProxyRepositoriesPath.AppendPart( aUrl.Value );
                                     if( Directory.Exists( candidate ) )
                                     {
-                                        url = new Uri( "file:///" + candidate, UriKind.Absolute );
+                                        url = new Uri( candidate );
                                         monitor.Trace( $"Automatic Repository Proxy mapping of Url=\"{aUrl.Value}\" to '{url}'." );
                                     }
                                 }

--- a/Tests/CKli.Core.Tests/PluginTests.cs
+++ b/Tests/CKli.Core.Tests/PluginTests.cs
@@ -347,11 +347,11 @@ public class PluginTests
         display.Clear();
         // ckli issue
         (await CKliCommands.ExecAsync( TestHelper.Monitor, context, "issue" )).ShouldBeTrue();
-        display.ToString().ShouldBe( """
+        display.ToString().Replace('\\','/').ShouldBe( """
             > EmptySolution (1)
             │ > ✋ Empty solution file.
             │ │ Ignoring 2 projects:
-            │ │ CodeCakeBuilder\CodeCakeBuilder.csproj, SomeJsApp\SomeJsApp.esproj
+            │ │ CodeCakeBuilder/CodeCakeBuilder.csproj, SomeJsApp/SomeJsApp.esproj
             > MissingSolution (1)
             │ > ✋ No solution found. Expecting 'MissingSolution.sln' (or '.slnx').
             > MultipleSolutions (1)
@@ -380,15 +380,15 @@ public class PluginTests
         context = context.ChangeDirectory( ".." );
         display.Clear();
         (await CKliCommands.ExecAsync( TestHelper.Monitor, context, "issue" )).ShouldBeTrue();
-        display.ToString().ShouldBe( """
+        display.ToString().Replace('\\','/').ShouldBe( """
             > EmptySolution (1)
             │ > ✋ Empty solution file.
             │ │ Ignoring 2 projects:
-            │ │ CodeCakeBuilder\CodeCakeBuilder.csproj, SomeJsApp\SomeJsApp.esproj
+            │ │ CodeCakeBuilder/CodeCakeBuilder.csproj, SomeJsApp/SomeJsApp.esproj
             > MissingSolution (1)
             │ > ✋ No solution found. Expecting 'MissingSolution.sln' (or '.slnx').
             ❰✓❱
-            
+
             """ );
 
     }

--- a/Tests/CKli.Core.Tests/StackRepositoryTests.cs
+++ b/Tests/CKli.Core.Tests/StackRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using CK.Core;
 using NUnit.Framework;
 using Shouldly;
@@ -298,13 +299,12 @@ public class StackRepositoryTests
         var display = (StringScreen)context.Screen;
         var remotes = TestEnv.OpenRemotes( "CKt" );
 
-        var stackUrl = remotes.StackUri.ToString();
-        stackUrl.ShouldStartWith( "file:///" );
-        stackUrl = stackUrl.Substring( 8 ).ToLowerInvariant();
+        var stackUrl = remotes.StackUri.LocalPath;
+        stackUrl = stackUrl.ToLowerInvariant();
         Assume.That( Directory.Exists( stackUrl ), "This test can only run on case insensitive file system." );
 
         // ckli clone ...ckt-stack
-        (await CKliCommands.ExecAsync( TestHelper.Monitor, context, "clone", "file:///" + stackUrl )).ShouldBeTrue();
+        (await CKliCommands.ExecAsync( TestHelper.Monitor, context, "clone", new Uri( stackUrl ) )).ShouldBeTrue();
 
         var folders = Directory.EnumerateDirectories( context.CurrentDirectory )
             .Select( path => Path.GetFileName( path ) )

--- a/Tests/CKli.Core.Tests/TestHelpers/TestEnv.RemotesCollection.cs
+++ b/Tests/CKli.Core.Tests/TestHelpers/TestEnv.RemotesCollection.cs
@@ -27,10 +27,11 @@ static partial class TestEnv
 
         public Uri GetUriFor( string repositoryName )
         {
-            var safe = _repositoryNames.Contains( repositoryName )
-                            ? $"file:///{_barePath}/{_name}/{repositoryName}"
-                            : $"file:///Missing '{repositoryName}' repository in '{_name}' remotes";
-            return new Uri( safe, UriKind.Absolute );
+            if( _repositoryNames.Contains( repositoryName ) )
+            {
+                return new Uri( _barePath.AppendPart( _name ).AppendPart( repositoryName ) );
+            }
+            return new Uri( "file:///Missing '" + repositoryName + "' repository in '" + _name + "' remotes" );
         }
 
         public override string ToString() => $"{_name} - {_repositoryNames.Length} repositories";

--- a/Tests/CKli.Core.Tests/TestHelpers/TestEnv.cs
+++ b/Tests/CKli.Core.Tests/TestHelpers/TestEnv.cs
@@ -66,7 +66,9 @@ static partial class TestEnv
         };
         var corePath = CopyMostRecentPackageToNuGetSource( "CKli.Core" );
         var pluginsPath = CopyMostRecentPackageToNuGetSource( "CKli.Plugins.Core" );
-        
+        NuGetHelper.ClearGlobalCache( TestHelper.Monitor, "CKli.Core", null );
+        NuGetHelper.ClearGlobalCache( TestHelper.Monitor, "CKli.Plugins.Core", null );
+
         foreach( var nuget in Directory.EnumerateFiles( _nugetSourcePath ) )
         {
             var p = new NormalizedPath( nuget );
@@ -104,7 +106,7 @@ static partial class TestEnv
 
         var zipPath = _remotesPath.AppendPart( "Remotes.zip" );
         var zipTime = File.GetLastWriteTimeUtc( zipPath );
-        if( !File.Exists( remoteIndexPath ) 
+        if( !File.Exists( remoteIndexPath )
             || File.GetLastWriteTimeUtc( remoteIndexPath ) != zipTime )
         {
             using( TestHelper.Monitor.OpenInfo( $"Last write time of 'Remotes/' differ from 'Remotes/Remotes.zip'. Restoring remotes from zip." ) )
@@ -116,7 +118,7 @@ static partial class TestEnv
                                .Select( l => l.Split( '/' ) )
                                .GroupBy( names => names[0], names => names[1] )
                                .Select( g => new RemotesCollection( g.Key, g.ToArray() ) )
-                               .ToDictionary( r => r.Name ); 
+                               .ToDictionary( r => r.Name );
 
         static void RestoreRemotesZipAndCreateBareRepositories( NormalizedPath remoteIndexPath, NormalizedPath zipPath, DateTime zipTime )
         {
@@ -280,7 +282,7 @@ static partial class TestEnv
         var v = version != null ? SVersion.Parse( version ) : _cKliPluginsCoreVersion;
 
         var path = _packagedPluginsPath.AppendPart( projectName );
-        var args = $"""pack -tl:off --no-dependencies -o "{_nugetSourcePath}" -c {TestHelper.BuildConfiguration} /p:IsPackable=true /p:Version={v}""";
+        var args = $"""pack -tl:off --no-dependencies -o "{_nugetSourcePath}" -c {TestHelper.BuildConfiguration} /p:IsPackable=true /p:Version={v} /p:RestoreAdditionalSources="{_nugetSourcePath}" """;
         using var _ = TestHelper.Monitor.OpenInfo( $"""
             Ensure plugin package '{projectName}':
             dotnet {args}


### PR DESCRIPTION
This PR fixes several issues that prevented CKli from building and booting correctly on Linux.

Note: There are other outstanding issues with Linux compat (in e.g. ckli exec and ckli update, which are not supported yet). This PR is just for build and core run/ckli clone.

# Changes

## Named Mutex Fix (`CKliRootEnv.cs`)
- Replace invalid characters in mutex names on Linux (forward slashes are not allowed in mutex names on non-Windows platforms)
- The `Global\` prefix [is a Windows convention](https://learn.microsoft.com/en-us/windows/win32/sync/object-names) for [termsrv compatibility](https://learn.microsoft.com/en-us/windows/win32/termserv/kernel-object-namespaces) (which I didn't know about before googling it, admittedly). On Linux, the `Global\` prefix has no special meaning - it's just part of the name string. Since it has a backslash and not a forward slash, this mutex name is valid.

## URI Generation (`WorldDefinitionFile.cs`, `TestEnv.RemotesCollection.cs`)
- Use new `Uri(path)` instead of manual `file:///` concatenation to generate correct URIs on Linux (avoids invalid `file://home` format for absolute paths)

## Test Fixes
- Add `RestoreAdditionalSources` to `dotnet pack` in tests to resolve plugin dependencies from the temporary NuGet source
- Clear `CKli.Core` and `CKli.Plugins.Core` from global NuGet cache to prevent version mismatch issues
- Normalize path separators (backslash to forward slash) when comparing command output
- Adjust trailing space expectations in `StringScreen` tests
- Skip `Clone_with_diff_casing_Async` test on case-sensitive file systems